### PR TITLE
use original apikey protocol before forward request to iota

### DIFF
--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -172,7 +172,10 @@ function createRequest(req, protocol, body) {
         protocolObj = req.protocolObj[protocol];
 
     delete options.qs.protocol;
-
+    // Save original apikey before be overwrite by apikey from body (probably modified)
+    if (req.query.apikey) {
+        options.qs.apikey_req = req.query.apikey;
+    }
     if (protocolObj.iotagent.substr(-1) === '/') {
         options.uri = protocolObj.iotagent.slice(0, -1) + req.path;
     } else {
@@ -223,7 +226,10 @@ function processRequests(req, res, next) {
 
     function sendRequest(options, callback) {
         logger.debug(context, 'Sending redirection with following options: %j', options);
-
+        // Use original apikey, not apikey from body
+        if (options.qs.apikey_req) {
+            options.qs.apikey = options.qs.apikey_req;
+        }
         request(options, function(error, response, body) {
             if (error) {
                 logger.error(context, 'Error found redirecting requests: %j', error);


### PR DESCRIPTION
In case of modify protocol (PUT) apikey protocol is overwrited by body apikey. So original apikey should be used instead of new.