### PR TITLE
add missed attributes to be translated (configuration)

### DIFF
--- a/lib/services/configurationData.js
+++ b/lib/services/configurationData.js
@@ -126,11 +126,7 @@ function createGetWithFields(fields) {
                         new_result[attributeList[i]] =
                             results[0][j][attributeList[i]];
                     }
-                    // Translation just for list
-                    if (fields['service']) {
-                         results[0][j] = new_result;
-                    }
-
+                    results[0][j] = new_result;
                 }
                 logger.debug(context, 'translated configurations %j', results[0]);
                 callback(null, {

--- a/lib/services/configurationData.js
+++ b/lib/services/configurationData.js
@@ -44,7 +44,8 @@ var Configuration = require('../model/Configuration'),
         /* jshint camelcase:false */
         subservice: 'service_path',
         type: 'entity_type',
-        internalAttributes: 'internal_attributes'
+        internalAttributes: 'internal_attributes',
+        staticAttributes: 'static_attributes'
     };
 
 
@@ -58,10 +59,14 @@ function createGetWithFields(fields) {
             offset,
             attributeList = [
                 '_id',
+                '__v',
+                'url',
+                'iotagent',
+                'token',
+                'apikey',
                 'type',
                 'subservice',
                 'service',
-                'apikey',
                 'resource',
                 'iotagent',
                 'description',
@@ -70,7 +75,9 @@ function createGetWithFields(fields) {
                 'attributes',
                 'lazy',
                 'staticAttributes',
-                'commands'
+                'commands',
+                'cbHost',
+                'timezone'
             ];
 
         while (typeof arguments[i] !== 'function') {
@@ -109,11 +116,22 @@ function createGetWithFields(fields) {
                 // Transate using retrievingAPI
                 logger.debug(context, 'translating configurations %j', results[0]);
                 for (var j = 0; j < results[0].length; j++) {
-                     for (var i = 0; i < attributeList.length; i++) {
-                         results[0][j][retrievingAPITranslation[attributeList[i]] || attributeList[i]] =
-                             results[0][j][attributeList[i]];
-                     }
+                    var new_result = {};
+                    for (var i = 0; i < attributeList.length; i++) {
+                        if (results[0][j][attributeList[i]]) {
+                            // Adding translate but keeps translated
+                            if (retrievingAPITranslation[attributeList[i]]) {
+                                new_result[retrievingAPITranslation[attributeList[i]]] =
+                                    results[0][j][attributeList[i]];
+                            }
+                            new_result[attributeList[i]] =
+                                results[0][j][attributeList[i]];
+                        }
+
+                    }
+                    results[0][j] = new_result;
                 }
+                logger.debug(context, 'translated configurations %j', results[0]);
                 callback(null, {
                     services: results[0],
                     count: results[1]

--- a/lib/services/configurationData.js
+++ b/lib/services/configurationData.js
@@ -118,7 +118,7 @@ function createGetWithFields(fields) {
                 for (var j = 0; j < results[0].length; j++) {
                     var new_result = {};
                     for (var i = 0; i < attributeList.length; i++) {
-                        // Adding translate but keeps translated
+                        // Adding translated fields but keeps previous
                         if (retrievingAPITranslation[attributeList[i]]) {
                             new_result[retrievingAPITranslation[attributeList[i]]] =
                                 results[0][j][attributeList[i]];

--- a/lib/services/configurationData.js
+++ b/lib/services/configurationData.js
@@ -126,7 +126,11 @@ function createGetWithFields(fields) {
                         new_result[attributeList[i]] =
                             results[0][j][attributeList[i]];
                     }
-                    results[0][j] = new_result;
+                    // Translation just for list
+                    if (fields['service']) {
+                         results[0][j] = new_result;
+                    }
+
                 }
                 logger.debug(context, 'translated configurations %j', results[0]);
                 callback(null, {

--- a/lib/services/configurationData.js
+++ b/lib/services/configurationData.js
@@ -36,16 +36,8 @@ var Configuration = require('../model/Configuration'),
         name: 'id',
         service: 'service',
         service_path: 'subservice',
-        entity_name: 'name',
         entity_type: 'type',
         internal_attributes: 'internalAttributes'
-    },
-    retrievingAPITranslation = {
-        /* jshint camelcase:false */
-        subservice: 'service_path',
-        type: 'entity_type',
-        internalAttributes: 'internal_attributes',
-        staticAttributes: 'static_attributes'
     };
 
 
@@ -56,29 +48,7 @@ function createGetWithFields(fields) {
             i = 0,
             callback,
             limit,
-            offset,
-            attributeList = [
-                '_id',
-                '__v',
-                'url',
-                'iotagent',
-                'token',
-                'apikey',
-                'type',
-                'subservice',
-                'service',
-                'resource',
-                'iotagent',
-                'description',
-                'protocol',
-                'internalAttributes',
-                'attributes',
-                'lazy',
-                'staticAttributes',
-                'commands',
-                'cbHost',
-                'timezone'
-            ];
+            offset;
 
         while (typeof arguments[i] !== 'function') {
             if (arguments[i]) {
@@ -113,14 +83,6 @@ function createGetWithFields(fields) {
             Configuration.model.count.bind(Configuration.model, queryObj)
         ], function(error, results) {
             if (!error && results && results.length === 2) {
-
-                for (var j = 0; j < results[0].length; j++) {
-                    for (var i = 0; i < attributeList.length; i++) {
-                        results[0][j][retrievingAPITranslation[attributeList[i]] || attributeList[i]] =
-                            results[0][j][attributeList[i]];
-                    }
-                }
-
                 callback(null, {
                     services: results[0],
                     count: results[1]

--- a/lib/services/configurationData.js
+++ b/lib/services/configurationData.js
@@ -118,16 +118,13 @@ function createGetWithFields(fields) {
                 for (var j = 0; j < results[0].length; j++) {
                     var new_result = {};
                     for (var i = 0; i < attributeList.length; i++) {
-                        if (results[0][j][attributeList[i]]) {
-                            // Adding translate but keeps translated
-                            if (retrievingAPITranslation[attributeList[i]]) {
-                                new_result[retrievingAPITranslation[attributeList[i]]] =
-                                    results[0][j][attributeList[i]];
-                            }
-                            new_result[attributeList[i]] =
+                        // Adding translate but keeps translated
+                        if (retrievingAPITranslation[attributeList[i]]) {
+                            new_result[retrievingAPITranslation[attributeList[i]]] =
                                 results[0][j][attributeList[i]];
                         }
-
+                        new_result[attributeList[i]] =
+                            results[0][j][attributeList[i]];
                     }
                     results[0][j] = new_result;
                 }

--- a/lib/services/configurationData.js
+++ b/lib/services/configurationData.js
@@ -113,22 +113,14 @@ function createGetWithFields(fields) {
             Configuration.model.count.bind(Configuration.model, queryObj)
         ], function(error, results) {
             if (!error && results && results.length === 2) {
-                // Transate using retrievingAPI
-                logger.debug(context, 'translating configurations %j', results[0]);
+
                 for (var j = 0; j < results[0].length; j++) {
-                    var new_result = {};
                     for (var i = 0; i < attributeList.length; i++) {
-                        // Adding translated fields but keeps previous
-                        if (retrievingAPITranslation[attributeList[i]]) {
-                            new_result[retrievingAPITranslation[attributeList[i]]] =
-                                results[0][j][attributeList[i]];
-                        }
-                        new_result[attributeList[i]] =
+                        results[0][j][retrievingAPITranslation[attributeList[i]] || attributeList[i]] =
                             results[0][j][attributeList[i]];
                     }
-                    results[0][j] = new_result;
                 }
-                logger.debug(context, 'translated configurations %j', results[0]);
+
                 callback(null, {
                     services: results[0],
                     count: results[1]

--- a/lib/services/configurations.js
+++ b/lib/services/configurations.js
@@ -24,7 +24,14 @@
 'use strict';
 
 var errors = require('../errors'),
-    configurationData = require('./configurationData');
+    configurationData = require('./configurationData'),
+    retrievingAPITranslation = {
+        /* jshint camelcase:false */
+        subservice: 'service_path',
+        type: 'entity_type',
+        internalAttributes: 'internal_attributes',
+        staticAttributes: 'static_attributes'
+    };
 
 function isInvalidParameter(param) {
     var value = parseInt(param);
@@ -42,6 +49,48 @@ function validateListParameters(req, res, next) {
     }
 }
 
+function translateToApi(configurations) {
+    var services = [],
+        attributeList = [
+            '_id',
+            '__v',
+            'url',
+            'iotagent',
+            'token',
+            'apikey',
+            'type',
+            'subservice',
+            'service',
+            'resource',
+            'iotagent',
+            'description',
+            'protocol',
+            'internalAttributes',
+            'attributes',
+            'lazy',
+            'staticAttributes',
+            'commands',
+            'cbHost',
+            'timezone'
+        ];
+
+    for (var j = 0; j < configurations.services.length; j++) {
+        var service = {};
+
+        for (var i = 0; i < attributeList.length; i++) {
+            service[retrievingAPITranslation[attributeList[i]] || attributeList[i]] =
+                configurations.services[j][attributeList[i]];
+        }
+
+        services.push(service);
+    }
+
+    return {
+        services: services,
+        count: configurations.count
+    };
+}
+
 function handleListRequest(req, res, next) {
     configurationData.list(
         req.headers['fiware-service'],
@@ -53,7 +102,7 @@ function handleListRequest(req, res, next) {
             if (error) {
                 next(error);
             } else {
-                res.status(200).json(configurations);
+                res.status(200).json(translateToApi(configurations));
             }
         });
 }

--- a/test/unit/configuration-retrieval-test.js
+++ b/test/unit/configuration-retrieval-test.js
@@ -133,6 +133,23 @@ describe('Configuration list', function() {
             });
         });
 
+        it('should map the attributes for the configurations appropriately', function(done) {
+            request(options, function(error, response, body) {
+                var parsedBody = JSON.parse(body);
+
+                for (var i = 0; i < parsedBody.services.length; i++) {
+                    should.exist(parsedBody.services[i].entity_type);
+                    should.not.exist(parsedBody.services[i].type);
+                    should.exist(parsedBody.services[i].service_path);
+                    should.not.exist(parsedBody.services[i].subservice);
+                    should.exist(parsedBody.services[i].internal_attributes);
+                    should.not.exist(parsedBody.services[i].internalAttributes);
+                }
+
+                done();
+            });
+        });
+
         it('should not return any configurations for other services', function(done) {
             request(options, function(error, response, body) {
                 var parsedBody = JSON.parse(body),


### PR DESCRIPTION
Iotportal, due to backward compability with iotacpp manager, expects a configuration with the following field names:

'service_path',
'entity_type',
'internal_attributes',
'static_attributes'