### PR TITLE
Fix/translate body (iota redirector)

### DIFF
--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -209,10 +209,22 @@ function createRequest(req, protocol, body) {
             delete item.protocol;
             return item;
         });
+        // Translate body.services
+        body.services = body.services.map(function translate(item) {
+            // entity_type -> type
+            item.type = item.entity_type;
+            delete item.entity_type;
+            // static_attributes -> staticAttributes
+            item.staticAttributes = item.static_attributes;
+            delete item.static_attributes;
+            return item;
+        });
     }
 
     if (req.method === 'PUT' || req.method === 'POST') {
         options.body = JSON.stringify(body);
+
+
     }
 
     delete options.headers['content-length'];

--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -212,9 +212,6 @@ function createRequest(req, protocol, body) {
         // Translate body.services
 
         if (req.method === 'PUT') {
-            var services = body.services.map(function translate(item) {
-                return item;
-            });
             body = services[0];
         }
     }

--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -214,15 +214,16 @@ function createRequest(req, protocol, body) {
         if (req.method === 'PUT') {
             body = body.services.map(function translate(item) {
 
-            // Is it neccesary that IOTAM translate body for IOTA or IOTA does it?
-            // // entity_type -> type
-            // item.type = item.entity_type;
-            // delete item.entity_type;
-            // // static_attributes -> staticAttributes
-            // item.staticAttributes = item.static_attributes;
-            // delete item.static_attributes;
-            return item;
-        });
+                // Is it neccesary that IOTAM translate body for IOTA or IOTA does it?
+                // // entity_type -> type
+                // item.type = item.entity_type;
+                // delete item.entity_type;
+                // // static_attributes -> staticAttributes
+                // item.staticAttributes = item.static_attributes;
+                // delete item.static_attributes;
+                return item;
+            });
+        }
     }
 
     if (req.method === 'PUT' || req.method === 'POST') {

--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -210,13 +210,17 @@ function createRequest(req, protocol, body) {
             return item;
         });
         // Translate body.services
-        body.services = body.services.map(function translate(item) {
-            // entity_type -> type
-            item.type = item.entity_type;
-            delete item.entity_type;
-            // static_attributes -> staticAttributes
-            item.staticAttributes = item.static_attributes;
-            delete item.static_attributes;
+
+        if (req.method === 'PUT') {
+            body = body.services.map(function translate(item) {
+
+            // Is it neccesary that IOTAM translate body for IOTA or IOTA does it?
+            // // entity_type -> type
+            // item.type = item.entity_type;
+            // delete item.entity_type;
+            // // static_attributes -> staticAttributes
+            // item.staticAttributes = item.static_attributes;
+            // delete item.static_attributes;
             return item;
         });
     }

--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -212,7 +212,7 @@ function createRequest(req, protocol, body) {
         // Translate body.services
 
         if (req.method === 'PUT') {
-            body = services[0];
+            body = body.services[0];
         }
     }
 

--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -218,8 +218,6 @@ function createRequest(req, protocol, body) {
 
     if (req.method === 'PUT' || req.method === 'POST') {
         options.body = JSON.stringify(body);
-
-
     }
 
     delete options.headers['content-length'];

--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -212,7 +212,7 @@ function createRequest(req, protocol, body) {
         // Translate body.services
 
         if (req.method === 'PUT') {
-            body = body.services.map(function translate(item) {
+            var services = body.services.map(function translate(item) {
 
                 // Is it neccesary that IOTAM translate body for IOTA or IOTA does it?
                 // // entity_type -> type
@@ -223,6 +223,7 @@ function createRequest(req, protocol, body) {
                 // delete item.static_attributes;
                 return item;
             });
+            body = services[0];
         }
     }
 

--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -213,14 +213,6 @@ function createRequest(req, protocol, body) {
 
         if (req.method === 'PUT') {
             var services = body.services.map(function translate(item) {
-
-                // Is it neccesary that IOTAM translate body for IOTA or IOTA does it?
-                // // entity_type -> type
-                // item.type = item.entity_type;
-                // delete item.entity_type;
-                // // static_attributes -> staticAttributes
-                // item.staticAttributes = item.static_attributes;
-                // delete item.static_attributes;
                 return item;
             });
             body = services[0];

--- a/test/examples/provisioning/putGroup.json
+++ b/test/examples/provisioning/putGroup.json
@@ -1,16 +1,6 @@
 {
-  "services": [
-    {
-      "resource": "/deviceTest",
-      "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
-      "type": "Light",
-      "trust": "TheNewTrust"
-    },
-    {
-      "resource": "/deviceTest",
-      "apikey": "23HJK3Y9090DSFL173209HV8801232",
-      "type": "Termometer",
-      "trust": "TheNewTrust"
-    }
-  ]
+    "resource": "/deviceTest",
+    "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
+    "type": "Light",
+    "trust": "TheNewTrust"
 }

--- a/test/unit/configuration-retrieval-test.js
+++ b/test/unit/configuration-retrieval-test.js
@@ -128,7 +128,7 @@ describe('Configuration list', function() {
             request(options, function(error, response, body) {
                 var parsedBody = JSON.parse(body);
 
-                parsedBody.services.length.should.greaterThan(6);
+                parsedBody.services.length.should.greaterThan(5);
                 done();
             });
         });
@@ -207,7 +207,7 @@ describe('Configuration list', function() {
             request(options, function(error, response, body) {
                 var parsedBody = JSON.parse(body);
 
-                parsedBody.services.length.should.greaterThan(4);
+                parsedBody.services.length.should.greaterThan(3);
                 done();
             });
         });


### PR DESCRIPTION
This is a fix for a bug during modify protocol (PUT) request

http://<iotamanager>services?apikey=<apikey>&protocol=IoTA-UL

with body:
```
{
"services": [{"apikey":"25lsji8tpnuy0riziom9q5xfz","attributes":[],"entity_type":"thingone","protocol":["IoTA-UL"],"static_attributes":[]}]
}
```

IOTA expects a body like
```
{
    "apikey": "ljhnkzbzppsgqxtb131u4a72d",
    "attributes": [],
    "entity_type": "window",
    "static_attributes": []
}
```
instead of 
```
{
    "services": [
        {
            "apikey": "0pdbxjst6zdmzptbwrohvi75w",
            "attributes": [],
            "type": "thingfour",
            "staticAttributes": []
        }
    ]
}
```

- [ ] Test updated