### PR TITLE
fix totalCount of devices checking really each iota response array

### DIFF
--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -342,12 +342,12 @@ function processRequests(req, res, next) {
             } else {
                 // Check if really there are some results in response
                 if (results[i][1][collectionName]) {
-                    if (results[i][1][collectionName].length > 0){
+                    if (results[i][1][collectionName].length > 0) {
                         totalCount += results[i][1][collectionName].length;
                     }
                 }
                 else {
-                    if (results[i][1].length > 0){
+                    if (results[i][1].length > 0) {
                         totalCount += results[i][1].length;
                     }
                 }

--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -352,7 +352,7 @@ function processRequests(req, res, next) {
                     }
                 }
                 // Detect single device response but not Repsol empty device response
-                if ('attributes' in results[i][1]){
+                if ('attributes' in results[i][1]) {
                     totalCount++;
                 }
             }

--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -352,7 +352,7 @@ function processRequests(req, res, next) {
                     }
                 }
                 // Detect single device response but not Repsol empty device response
-                if ("attributes" in results[i][1]){
+                if ('attributes' in results[i][1]){
                     totalCount++;
                 }
             }

--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -351,6 +351,10 @@ function processRequests(req, res, next) {
                         totalCount += results[i][1].length;
                     }
                 }
+                // Detect single device response but not Repsol empty device response
+                if ("attributes" in results[i][1]){
+                    totalCount++;
+                }
             }
 
             if (results[i][1][collectionName]) {

--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -317,7 +317,8 @@ function processRequests(req, res, next) {
     function combineResults(results) {
         /* jshint camelcase: false */
 
-        var finalResult = [],
+        var totalCount = 0,
+            finalResult = [],
             collectionName,
             resultObj = {};
 
@@ -336,6 +337,22 @@ function processRequests(req, res, next) {
         for (var i = 0; i < results.length; i++) {
             logger.debug(context, 'results[%s][1] %j ', i, results[i][1]);
 
+            if (results[i][1].count) {
+                totalCount += results[i][1].count;
+            } else {
+                // Check if really there are some results in response
+                if (results[i][1][collectionName]) {
+                    if (results[i][1][collectionName].length > 0){
+                        totalCount += results[i][1][collectionName].length;
+                    }
+                }
+                else {
+                    if (results[i][1].length > 0){
+                        totalCount += results[i][1].length;
+                    }
+                }
+            }
+
             if (results[i][1][collectionName]) {
                 finalResult = finalResult.concat(results[i][1][collectionName]);
             } else {
@@ -343,7 +360,7 @@ function processRequests(req, res, next) {
             }
         }
 
-        resultObj.count = finalResult.length;
+        resultObj.count = totalCount;
         resultObj[collectionName] = finalResult;
 
         return resultObj;


### PR DESCRIPTION
Fix for https://jirapdi.tid.es/browse/DM-2423
This PR fixes ```count``` returned by iotagent-manager when listing devices. But still no return a number as limit was set.