### PR TITLE
Step: 1.2.0-next -> 1.3.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,0 @@
-- FIx: add mongodb dependence into dependencies in package.json

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,16 +1,16 @@
 {
   "name": "iotagent-manager",
-  "version": "1.2.0-next",
+  "version": "1.3.0",
   "dependencies": {
     "async": {
       "version": "2.0.1",
       "from": "async@2.0.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-2.0.1.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
+          "version": "4.17.5",
           "from": "lodash@>=4.8.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz"
         }
       }
     },
@@ -22,7 +22,7 @@
         "bytes": {
           "version": "3.0.0",
           "from": "bytes@3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz"
+          "resolved": "http://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz"
         },
         "content-type": {
           "version": "1.0.4",
@@ -32,29 +32,34 @@
         "debug": {
           "version": "2.6.9",
           "from": "debug@2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "dependencies": {
             "ms": {
               "version": "2.0.0",
               "from": "ms@2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
             }
           }
         },
         "depd": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "from": "depd@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
+          "resolved": "http://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
         },
         "http-errors": {
           "version": "1.6.2",
           "from": "http-errors@>=1.6.2 <1.7.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
           "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "from": "depd@1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
+            },
             "inherits": {
               "version": "2.0.3",
               "from": "inherits@2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "setprototypeof": {
               "version": "1.0.3",
@@ -64,7 +69,7 @@
             "statuses": {
               "version": "1.4.0",
               "from": "statuses@>=1.3.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
+              "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
             }
           }
         },
@@ -81,7 +86,7 @@
             "ee-first": {
               "version": "1.1.1",
               "from": "ee-first@1.1.1",
-              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+              "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
@@ -93,34 +98,34 @@
         "raw-body": {
           "version": "2.3.2",
           "from": "raw-body@2.3.2",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+          "resolved": "http://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
           "dependencies": {
             "unpipe": {
               "version": "1.0.0",
               "from": "unpipe@1.0.0",
-              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+              "resolved": "http://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "type-is": {
-          "version": "1.6.15",
+          "version": "1.6.16",
           "from": "type-is@>=1.6.15 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+          "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
               "from": "media-typer@0.3.0",
-              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+              "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.17",
-              "from": "mime-types@>=2.1.15 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+              "version": "2.1.18",
+              "from": "mime-types@>=2.1.18 <2.2.0",
+              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.30.0",
-                  "from": "mime-db@>=1.30.0 <1.31.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
+                  "version": "1.33.0",
+                  "from": "mime-db@>=1.33.0 <1.34.0",
+                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz"
                 }
               }
             }
@@ -131,7 +136,7 @@
     "express": {
       "version": "4.16.2",
       "from": "express@>=4.11.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "resolved": "http://registry.npmjs.org/express/-/express-4.16.2.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.3.4",
@@ -139,33 +144,33 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.1.17",
-              "from": "mime-types@>=2.1.15 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+              "version": "2.1.18",
+              "from": "mime-types@>=2.1.16 <2.2.0",
+              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.30.0",
-                  "from": "mime-db@>=1.30.0 <1.31.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
+                  "version": "1.33.0",
+                  "from": "mime-db@>=1.33.0 <1.34.0",
+                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.6.1",
               "from": "negotiator@0.6.1",
-              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+              "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
             }
           }
         },
         "array-flatten": {
           "version": "1.1.1",
           "from": "array-flatten@1.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+          "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
         },
         "content-disposition": {
           "version": "0.5.2",
           "from": "content-disposition@0.5.2",
-          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
+          "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
         },
         "content-type": {
           "version": "1.0.4",
@@ -175,34 +180,34 @@
         "cookie": {
           "version": "0.3.1",
           "from": "cookie@0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+          "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
           "from": "cookie-signature@1.0.6",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+          "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "debug": {
           "version": "2.6.9",
           "from": "debug@2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "dependencies": {
             "ms": {
               "version": "2.0.0",
               "from": "ms@2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
             }
           }
         },
         "depd": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "from": "depd@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
+          "resolved": "http://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
         },
         "encodeurl": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "from": "encodeurl@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+          "resolved": "http://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
         },
         "escape-html": {
           "version": "1.0.3",
@@ -217,24 +222,24 @@
         "finalhandler": {
           "version": "1.1.0",
           "from": "finalhandler@1.1.0",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
           "dependencies": {
             "unpipe": {
               "version": "1.0.0",
               "from": "unpipe@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+              "resolved": "http://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "fresh": {
           "version": "0.5.2",
           "from": "fresh@0.5.2",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
+          "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
         },
         "merge-descriptors": {
           "version": "1.0.1",
           "from": "merge-descriptors@1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+          "resolved": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
         },
         "methods": {
           "version": "1.1.2",
@@ -249,7 +254,7 @@
             "ee-first": {
               "version": "1.1.1",
               "from": "ee-first@1.1.1",
-              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+              "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
@@ -261,12 +266,12 @@
         "path-to-regexp": {
           "version": "0.1.7",
           "from": "path-to-regexp@0.1.7",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+          "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
         },
         "proxy-addr": {
-          "version": "2.0.2",
+          "version": "2.0.3",
           "from": "proxy-addr@>=2.0.2 <2.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.2",
@@ -274,9 +279,9 @@
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz"
             },
             "ipaddr.js": {
-              "version": "1.5.2",
-              "from": "ipaddr.js@1.5.2",
-              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz"
+              "version": "1.6.0",
+              "from": "ipaddr.js@1.6.0",
+              "resolved": "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz"
             }
           }
         },
@@ -293,12 +298,12 @@
         "safe-buffer": {
           "version": "5.1.1",
           "from": "safe-buffer@5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+          "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
         },
         "send": {
           "version": "0.16.1",
           "from": "send@0.16.1",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+          "resolved": "http://registry.npmjs.org/send/-/send-0.16.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.4",
@@ -310,10 +315,15 @@
               "from": "http-errors@>=1.6.2 <1.7.0",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
               "dependencies": {
+                "depd": {
+                  "version": "1.1.1",
+                  "from": "depd@1.1.1",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
+                },
                 "inherits": {
                   "version": "2.0.3",
                   "from": "inherits@2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "setprototypeof": {
                   "version": "1.0.3",
@@ -325,24 +335,24 @@
             "mime": {
               "version": "1.4.1",
               "from": "mime@1.4.1",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz"
+              "resolved": "http://registry.npmjs.org/mime/-/mime-1.4.1.tgz"
             },
             "ms": {
               "version": "2.0.0",
               "from": "ms@2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
             }
           }
         },
         "serve-static": {
           "version": "1.13.1",
           "from": "serve-static@1.13.1",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz"
+          "resolved": "http://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz"
         },
         "setprototypeof": {
           "version": "1.1.0",
           "from": "setprototypeof@1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
+          "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
         },
         "statuses": {
           "version": "1.3.1",
@@ -350,24 +360,24 @@
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
         },
         "type-is": {
-          "version": "1.6.15",
+          "version": "1.6.16",
           "from": "type-is@>=1.6.15 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+          "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
               "from": "media-typer@0.3.0",
-              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+              "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.17",
-              "from": "mime-types@>=2.1.15 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+              "version": "2.1.18",
+              "from": "mime-types@>=2.1.16 <2.2.0",
+              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.30.0",
-                  "from": "mime-db@>=1.30.0 <1.31.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
+                  "version": "1.33.0",
+                  "from": "mime-db@>=1.33.0 <1.34.0",
+                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz"
                 }
               }
             }
@@ -376,7 +386,7 @@
         "utils-merge": {
           "version": "1.0.1",
           "from": "utils-merge@1.0.1",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
+          "resolved": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
         },
         "vary": {
           "version": "1.1.2",
@@ -386,29 +396,29 @@
       }
     },
     "iotagent-node-lib": {
-      "version": "2.5.0-next",
-      "from": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
-      "resolved": "git://github.com/telefonicaid/iotagent-node-lib.git#603d1a9d3666ae228277102c32a8a294331519f2",
+      "version": "2.6.0",
+      "from": "iotagent-node-lib@>=2.6.0 <2.7.0",
+      "resolved": "http://registry.npmjs.org/iotagent-node-lib/-/iotagent-node-lib-2.6.0.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
           "from": "async@1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "command-shell-lib": {
           "version": "1.0.0",
           "from": "command-shell-lib@1.0.0",
-          "resolved": "https://registry.npmjs.org/command-shell-lib/-/command-shell-lib-1.0.0.tgz"
+          "resolved": "http://registry.npmjs.org/command-shell-lib/-/command-shell-lib-1.0.0.tgz"
         },
         "jison": {
           "version": "0.4.17",
           "from": "jison@0.4.17",
-          "resolved": "https://registry.npmjs.org/jison/-/jison-0.4.17.tgz",
+          "resolved": "http://registry.npmjs.org/jison/-/jison-0.4.17.tgz",
           "dependencies": {
             "JSONSelect": {
               "version": "0.4.0",
               "from": "JSONSelect@0.4.0",
-              "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz"
+              "resolved": "http://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz"
             },
             "esprima": {
               "version": "1.1.1",
@@ -452,7 +462,7 @@
             "ebnf-parser": {
               "version": "0.1.10",
               "from": "ebnf-parser@0.1.10",
-              "resolved": "https://registry.npmjs.org/ebnf-parser/-/ebnf-parser-0.1.10.tgz"
+              "resolved": "http://registry.npmjs.org/ebnf-parser/-/ebnf-parser-0.1.10.tgz"
             },
             "lex-parser": {
               "version": "0.1.4",
@@ -462,7 +472,7 @@
             "nomnom": {
               "version": "1.5.2",
               "from": "nomnom@1.5.2",
-              "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+              "resolved": "http://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.1.7",
@@ -479,12 +489,12 @@
             "cjson": {
               "version": "0.3.0",
               "from": "cjson@0.3.0",
-              "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
               "dependencies": {
                 "jsonlint": {
                   "version": "1.6.0",
                   "from": "jsonlint@1.6.0",
-                  "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+                  "resolved": "http://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
                   "dependencies": {
                     "JSV": {
                       "version": "4.0.2",
@@ -500,54 +510,54 @@
         "mongoose": {
           "version": "4.13.3",
           "from": "mongoose@4.13.3",
-          "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.13.3.tgz",
+          "resolved": "http://registry.npmjs.org/mongoose/-/mongoose-4.13.3.tgz",
           "dependencies": {
             "async": {
               "version": "2.1.4",
               "from": "async@2.1.4",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+              "resolved": "http://registry.npmjs.org/async/-/async-2.1.4.tgz",
               "dependencies": {
                 "lodash": {
-                  "version": "4.17.4",
+                  "version": "4.17.5",
                   "from": "lodash@>=4.14.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+                  "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz"
                 }
               }
             },
             "bson": {
-              "version": "1.0.4",
+              "version": "1.0.5",
               "from": "bson@>=1.0.4 <1.1.0",
-              "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz"
+              "resolved": "http://registry.npmjs.org/bson/-/bson-1.0.5.tgz"
             },
             "hooks-fixed": {
               "version": "2.0.2",
               "from": "hooks-fixed@2.0.2",
-              "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.2.tgz"
+              "resolved": "http://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.2.tgz"
             },
             "kareem": {
               "version": "1.5.0",
               "from": "kareem@1.5.0",
-              "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz"
+              "resolved": "http://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz"
             },
             "lodash.get": {
               "version": "4.4.2",
               "from": "lodash.get@4.4.2",
-              "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz"
+              "resolved": "http://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz"
             },
             "mongodb": {
               "version": "2.2.33",
               "from": "mongodb@2.2.33",
-              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.33.tgz",
+              "resolved": "http://registry.npmjs.org/mongodb/-/mongodb-2.2.33.tgz",
               "dependencies": {
                 "es6-promise": {
                   "version": "3.2.1",
                   "from": "es6-promise@3.2.1",
-                  "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
+                  "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
                 },
                 "mongodb-core": {
                   "version": "2.1.17",
                   "from": "mongodb-core@2.1.17",
-                  "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.17.tgz",
+                  "resolved": "http://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.17.tgz",
                   "dependencies": {
                     "require_optional": {
                       "version": "1.0.1",
@@ -555,9 +565,9 @@
                       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
                       "dependencies": {
                         "semver": {
-                          "version": "5.4.1",
+                          "version": "5.5.0",
                           "from": "semver@>=5.1.0 <6.0.0",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+                          "resolved": "http://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                         },
                         "resolve-from": {
                           "version": "2.0.0",
@@ -571,7 +581,7 @@
                 "readable-stream": {
                   "version": "2.2.7",
                   "from": "readable-stream@2.2.7",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
@@ -591,7 +601,7 @@
                     "inherits": {
                       "version": "2.0.3",
                       "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
@@ -606,7 +616,7 @@
                         "safe-buffer": {
                           "version": "5.1.1",
                           "from": "safe-buffer@>=5.1.0 <5.2.0",
-                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                          "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                         }
                       }
                     },
@@ -622,17 +632,17 @@
             "mpath": {
               "version": "0.3.0",
               "from": "mpath@0.3.0",
-              "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz"
+              "resolved": "http://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz"
             },
             "mpromise": {
               "version": "0.5.5",
               "from": "mpromise@0.5.5",
-              "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz"
+              "resolved": "http://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz"
             },
             "mquery": {
               "version": "2.3.2",
               "from": "mquery@2.3.2",
-              "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.2.tgz",
+              "resolved": "http://registry.npmjs.org/mquery/-/mquery-2.3.2.tgz",
               "dependencies": {
                 "bluebird": {
                   "version": "3.5.1",
@@ -642,7 +652,7 @@
                 "debug": {
                   "version": "2.6.9",
                   "from": "debug@>=2.6.9 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
                 },
                 "sliced": {
                   "version": "0.0.5",
@@ -654,22 +664,22 @@
             "ms": {
               "version": "2.0.0",
               "from": "ms@2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
             },
             "muri": {
               "version": "1.3.0",
               "from": "muri@1.3.0",
-              "resolved": "https://registry.npmjs.org/muri/-/muri-1.3.0.tgz"
+              "resolved": "http://registry.npmjs.org/muri/-/muri-1.3.0.tgz"
             },
             "regexp-clone": {
               "version": "0.0.1",
               "from": "regexp-clone@0.0.1",
-              "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
+              "resolved": "http://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
             },
             "sliced": {
               "version": "1.0.1",
               "from": "sliced@1.0.1",
-              "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz"
+              "resolved": "http://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz"
             }
           }
         },
@@ -681,7 +691,7 @@
         "mustache": {
           "version": "2.2.1",
           "from": "mustache@2.2.1",
-          "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.2.1.tgz"
+          "resolved": "http://registry.npmjs.org/mustache/-/mustache-2.2.1.tgz"
         },
         "node-uuid": {
           "version": "1.4.8",
@@ -696,14 +706,14 @@
         "xmldom": {
           "version": "0.1.19",
           "from": "xmldom@0.1.19",
-          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz"
+          "resolved": "http://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz"
         }
       }
     },
     "logops": {
       "version": "1.0.0",
       "from": "logops@1.0.0",
-      "resolved": "https://registry.npmjs.org/logops/-/logops-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/logops/-/logops-1.0.0.tgz",
       "dependencies": {
         "colors": {
           "version": "1.1.2",
@@ -716,9 +726,9 @@
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "lodash": {
-          "version": "4.17.4",
+          "version": "4.17.5",
           "from": "lodash@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz"
         },
         "serr": {
           "version": "0.3.0",
@@ -730,17 +740,17 @@
     "mongodb": {
       "version": "2.2.10",
       "from": "mongodb@2.2.10",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.10.tgz",
+      "resolved": "http://registry.npmjs.org/mongodb/-/mongodb-2.2.10.tgz",
       "dependencies": {
         "es6-promise": {
           "version": "3.2.1",
           "from": "es6-promise@3.2.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
+          "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
         },
         "mongodb-core": {
           "version": "2.0.12",
           "from": "mongodb-core@2.0.12",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.0.12.tgz",
+          "resolved": "http://registry.npmjs.org/mongodb-core/-/mongodb-core-2.0.12.tgz",
           "dependencies": {
             "bson": {
               "version": "0.5.7",
@@ -753,9 +763,9 @@
               "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
               "dependencies": {
                 "semver": {
-                  "version": "5.4.1",
+                  "version": "5.5.0",
                   "from": "semver@>=5.1.0 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+                  "resolved": "http://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                 },
                 "resolve-from": {
                   "version": "2.0.0",
@@ -769,7 +779,7 @@
         "readable-stream": {
           "version": "2.1.5",
           "from": "readable-stream@2.1.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
@@ -784,7 +794,7 @@
             "inherits": {
               "version": "2.0.3",
               "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "isarray": {
               "version": "1.0.0",
@@ -811,56 +821,56 @@
       }
     },
     "mongoose": {
-      "version": "4.13.4",
+      "version": "4.13.11",
       "from": "mongoose@>=4.1.5 <5.0.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.13.4.tgz",
+      "resolved": "http://registry.npmjs.org/mongoose/-/mongoose-4.13.11.tgz",
       "dependencies": {
         "async": {
           "version": "2.1.4",
           "from": "async@2.1.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-2.1.4.tgz",
           "dependencies": {
             "lodash": {
-              "version": "4.17.4",
+              "version": "4.17.5",
               "from": "lodash@>=4.14.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+              "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz"
             }
           }
         },
         "bson": {
-          "version": "1.0.4",
+          "version": "1.0.5",
           "from": "bson@>=1.0.4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz"
+          "resolved": "http://registry.npmjs.org/bson/-/bson-1.0.5.tgz"
         },
         "hooks-fixed": {
           "version": "2.0.2",
           "from": "hooks-fixed@2.0.2",
-          "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.2.tgz"
+          "resolved": "http://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.2.tgz"
         },
         "kareem": {
           "version": "1.5.0",
           "from": "kareem@1.5.0",
-          "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz"
+          "resolved": "http://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz"
         },
         "lodash.get": {
           "version": "4.4.2",
           "from": "lodash.get@4.4.2",
-          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz"
+          "resolved": "http://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz"
         },
         "mongodb": {
-          "version": "2.2.33",
-          "from": "mongodb@2.2.33",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.33.tgz",
+          "version": "2.2.34",
+          "from": "mongodb@2.2.34",
+          "resolved": "http://registry.npmjs.org/mongodb/-/mongodb-2.2.34.tgz",
           "dependencies": {
             "es6-promise": {
               "version": "3.2.1",
               "from": "es6-promise@3.2.1",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
+              "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
             },
             "mongodb-core": {
-              "version": "2.1.17",
-              "from": "mongodb-core@2.1.17",
-              "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.17.tgz",
+              "version": "2.1.18",
+              "from": "mongodb-core@2.1.18",
+              "resolved": "http://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.18.tgz",
               "dependencies": {
                 "require_optional": {
                   "version": "1.0.1",
@@ -868,9 +878,9 @@
                   "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
                   "dependencies": {
                     "semver": {
-                      "version": "5.4.1",
+                      "version": "5.5.0",
                       "from": "semver@>=5.1.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+                      "resolved": "http://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                     },
                     "resolve-from": {
                       "version": "2.0.0",
@@ -884,7 +894,7 @@
             "readable-stream": {
               "version": "2.2.7",
               "from": "readable-stream@2.2.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
               "dependencies": {
                 "buffer-shims": {
                   "version": "1.0.0",
@@ -904,7 +914,7 @@
                 "inherits": {
                   "version": "2.0.3",
                   "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
@@ -919,7 +929,7 @@
                     "safe-buffer": {
                       "version": "5.1.1",
                       "from": "safe-buffer@>=5.1.0 <5.2.0",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                      "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                     }
                   }
                 },
@@ -935,27 +945,27 @@
         "mpath": {
           "version": "0.3.0",
           "from": "mpath@0.3.0",
-          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz"
+          "resolved": "http://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz"
         },
         "mpromise": {
           "version": "0.5.5",
           "from": "mpromise@0.5.5",
-          "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz"
+          "resolved": "http://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz"
         },
         "mquery": {
-          "version": "2.3.2",
-          "from": "mquery@2.3.2",
-          "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.2.tgz",
+          "version": "2.3.3",
+          "from": "mquery@2.3.3",
+          "resolved": "http://registry.npmjs.org/mquery/-/mquery-2.3.3.tgz",
           "dependencies": {
             "bluebird": {
-              "version": "3.5.1",
-              "from": "bluebird@>=3.5.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz"
+              "version": "3.5.0",
+              "from": "bluebird@3.5.0",
+              "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
             },
             "debug": {
               "version": "2.6.9",
-              "from": "debug@>=2.6.9 <3.0.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+              "from": "debug@2.6.9",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
             },
             "sliced": {
               "version": "0.0.5",
@@ -967,34 +977,34 @@
         "ms": {
           "version": "2.0.0",
           "from": "ms@2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
         },
         "muri": {
           "version": "1.3.0",
           "from": "muri@1.3.0",
-          "resolved": "https://registry.npmjs.org/muri/-/muri-1.3.0.tgz"
+          "resolved": "http://registry.npmjs.org/muri/-/muri-1.3.0.tgz"
         },
         "regexp-clone": {
           "version": "0.0.1",
           "from": "regexp-clone@0.0.1",
-          "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
+          "resolved": "http://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
         },
         "sliced": {
           "version": "1.0.1",
           "from": "sliced@1.0.1",
-          "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz"
+          "resolved": "http://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz"
         }
       }
     },
     "request": {
       "version": "2.74.0",
       "from": "request@2.74.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+      "resolved": "http://registry.npmjs.org/request/-/request-2.74.0.tgz",
       "dependencies": {
         "aws-sign2": {
           "version": "0.6.0",
           "from": "aws-sign2@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+          "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
           "version": "1.6.0",
@@ -1004,12 +1014,12 @@
         "bl": {
           "version": "1.1.2",
           "from": "bl@>=1.1.2 <1.2.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.6",
               "from": "readable-stream@>=2.0.5 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
@@ -1019,7 +1029,7 @@
                 "inherits": {
                   "version": "2.0.3",
                   "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
@@ -1048,12 +1058,12 @@
         "caseless": {
           "version": "0.11.0",
           "from": "caseless@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+          "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "combined-stream": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "from": "combined-stream@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
@@ -1075,90 +1085,95 @@
         "form-data": {
           "version": "1.0.1",
           "from": "form-data@>=1.0.0-rc4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz"
+          "resolved": "http://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz"
         },
         "har-validator": {
           "version": "2.0.6",
           "from": "har-validator@>=2.0.6 <2.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
               "from": "chalk@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
                   "from": "ansi-styles@>=2.2.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                  "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
                   "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
                   "from": "has-ansi@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
                   "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
                   "from": "supports-color@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "commander": {
-              "version": "2.11.0",
+              "version": "2.14.1",
               "from": "commander@>=2.9.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
+              "resolved": "http://registry.npmjs.org/commander/-/commander-2.14.1.tgz"
             },
             "is-my-json-valid": {
-              "version": "2.16.1",
+              "version": "2.17.2",
               "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+              "resolved": "http://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
                   "from": "generate-function@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                  "resolved": "http://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
                   "from": "generate-object-property@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "resolved": "http://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
                       "from": "is-property@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                      "resolved": "http://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
+                },
+                "is-my-ip-valid": {
+                  "version": "1.0.0",
+                  "from": "is-my-ip-valid@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz"
                 },
                 "jsonpointer": {
                   "version": "4.0.1",
                   "from": "jsonpointer@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
+                  "resolved": "http://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
@@ -1184,39 +1199,39 @@
         "hawk": {
           "version": "3.1.3",
           "from": "hawk@>=3.1.3 <3.2.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
             "hoek": {
               "version": "2.16.3",
               "from": "hoek@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+              "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "boom": {
               "version": "2.10.1",
               "from": "boom@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+              "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.5",
               "from": "cryptiles@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+              "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
               "from": "sntp@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+              "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "http-signature": {
           "version": "1.1.1",
           "from": "http-signature@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.2.0",
               "from": "assert-plus@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+              "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
               "version": "1.4.1",
@@ -1231,17 +1246,17 @@
                 "extsprintf": {
                   "version": "1.3.0",
                   "from": "extsprintf@1.3.0",
-                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+                  "resolved": "http://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
                 },
                 "json-schema": {
                   "version": "0.2.3",
                   "from": "json-schema@0.2.3",
-                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                  "resolved": "http://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                 },
                 "verror": {
                   "version": "1.10.0",
                   "from": "verror@1.10.0",
-                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                  "resolved": "http://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -1317,14 +1332,14 @@
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
-          "version": "2.1.17",
+          "version": "2.1.18",
           "from": "mime-types@>=2.1.7 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.30.0",
-              "from": "mime-db@>=1.30.0 <1.31.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
+              "version": "1.33.0",
+              "from": "mime-db@>=1.33.0 <1.34.0",
+              "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz"
             }
           }
         },
@@ -1341,7 +1356,7 @@
         "qs": {
           "version": "6.2.3",
           "from": "qs@>=6.2.0 <6.3.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz"
+          "resolved": "http://registry.npmjs.org/qs/-/qs-6.2.3.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
@@ -1349,9 +1364,9 @@
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
-          "version": "2.3.3",
+          "version": "2.3.4",
           "from": "tough-cookie@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.4.1",
@@ -1363,7 +1378,7 @@
         "tunnel-agent": {
           "version": "0.4.3",
           "from": "tunnel-agent@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+          "resolved": "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         }
       }
     },
@@ -1375,7 +1390,7 @@
     "underscore": {
       "version": "1.8.3",
       "from": "underscore@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iotagent-manager",
   "description": "IoT Agent Manager proxy",
-  "version": "1.2.0-next",
+  "version": "1.3.0",
   "homepage": "https://github.com/dmj/iotagent-manager",
   "author": {
     "name": "Daniel Moran",
@@ -30,7 +30,7 @@
     "revalidator": "^0.3.1",
     "mongoose": "^4.1.5",
     "async": "2.0.1",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "2.6.x",
     "mongodb": "2.2.10"
   },
   "devDependencies": {

--- a/rpm/SPECS/iotamanager.spec
+++ b/rpm/SPECS/iotamanager.spec
@@ -162,6 +162,9 @@ fi
 %{_install_dir}
 
 %changelog
+* Tue Feb 27 2018 Fermin Galan <fermin.galanmarquez@telefonica.com> 1.3.0
+- Update ioagent-node-lib to 2.6.x
+- FIx: add mongodb dependence into dependencies in package.json
 
 * Wed Oct 28 2017 Fermin Galan <fermin.galanmarquez@telefonica.com> 1.2.0
 - FEATURE update node version to 4.8.4


### PR DESCRIPTION
Similar to PR https://github.com/telefonicaid/iotagent-manager/pull/126/files but

1. Upgrading iotagent-node-lib in packages.json (this was a bug in former PR)
2. Improved shrinkwrap.json generation, this way:

```
rm -rf node_modules
rm npm-shrinkwrap.json
npm install
npm shrinkwrap
```

executed in the reference CentOS 6 jenkins which used:

```
$ node --version
v4.8.4
$ npm --version
2.15.11
```