### PR TITLE
Step: 1.4.0 -> 1.4.0-next

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iotagent-manager",
   "description": "IoT Agent Manager proxy",
-  "version": "1.4.0",
+  "version": "1.4.0-next",
   "homepage": "https://github.com/dmj/iotagent-manager",
   "author": {
     "name": "Daniel Moran",
@@ -30,7 +30,7 @@
     "revalidator": "~0.3.1",
     "mongoose": "~4.1.5",
     "async": "2.0.1",
-    "iotagent-node-lib": "2.7.x"
+    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
Similar to PR https://github.com/telefonicaid/iotagent-manager/pull/137 (except npm-shrinkwrap.json generation, that is no longer included in repository)