### PR TITLE
 Upgrade mongoose dependency

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Upgrade mongoose dependency to 4.13.14

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "logops": "1.0.0",
     "underscore": "~1.7.0",
     "revalidator": "~0.3.1",
-    "mongoose": "~4.1.5",
+    "mongoose": "4.13.14",
     "async": "2.0.1",
     "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master"
   },


### PR DESCRIPTION
Old versions depends in sequence of a deprecated mongodb version.

CC: @cesarjorgemartinez 