### PR TITLE
add type to query protocol configuration

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+FIX: add `type` to query about configuration protocol

--- a/lib/services/configurationData.js
+++ b/lib/services/configurationData.js
@@ -68,7 +68,7 @@ function createGetWithFields(fields) {
 
         callback = arguments[i];
 
-        logger.debug('Looking for configuration with params %j', fields);
+        logger.debug('Looking for configuration with params %j and query %j', fields, queryObj);
 
         query = Configuration.model.find(queryObj);
 
@@ -136,7 +136,7 @@ function save(protocol, description, iotagent, resource, configuration, oldConfi
 
 exports.get = iotagentLib.alarms.intercept(
     iotagentLib.constants.MONGO_ALARM,
-    createGetWithFields(['apikey', 'resource', 'protocol']));
+    createGetWithFields(['apikey', 'resource', 'protocol', 'type']));
 
 exports.save = iotagentLib.alarms.intercept(
     iotagentLib.constants.MONGO_ALARM,
@@ -144,4 +144,4 @@ exports.save = iotagentLib.alarms.intercept(
 
 exports.list = iotagentLib.alarms.intercept(
     iotagentLib.constants.MONGO_ALARM,
-    createGetWithFields(['service', 'subservice', 'protocol', 'limit', 'offset']));
+    createGetWithFields(['service', 'subservice', 'protocol', 'apikey', 'type', 'limit', 'offset']));

--- a/lib/services/configurations.js
+++ b/lib/services/configurations.js
@@ -97,6 +97,8 @@ function handleListRequest(req, res, next) {
         req.headers['fiware-service'],
         req.headers['fiware-servicepath'],
         req.query.protocol,
+        req.query.apikey,
+        req.query.type,
         req.query.limit,
         req.query.offset,
         function(error, configurations) {


### PR DESCRIPTION
Since procotols configuration group are defined by [protocol, apikey, type] we should ensure that we can search a protocol not only using protocol, just by apikey and type, Because a configuration group protocol could have the same protocol but different apikey and type.