### PR TITLE
Fully Remove Node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
     strategy:
       matrix:
         node-version:
+          # FIXME: node v10 has been deprecated, but we are going to keep its regression for a while
+          - 10.x
           - 12.x
           - 14.x
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10.x
           - 12.x
           - 14.x
     steps:

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
-
+- Upgrade NodeJS version from 10 to 12 in Dockerfile due to Node 10 End-of-Life
+- Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@
 # For those usages not covered by the GNU Affero General Public License
 # please contact with: [sc_support at telefonica dot com]
 
-ARG NODE_VERSION=10
+ARG NODE_VERSION=12
 ARG GITHUB_ACCOUNT=telefonicaid
 ARG GITHUB_REPOSITORY=iotagent-manager
 ARG DOWNLOAD=latest

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "main": "lib/iotagent-manager",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "clean": "rm -rf package-lock.json && rm -rf node_modules && rm -rf coverage",


### PR DESCRIPTION
With the recent release, Node 10 can be fully removed for the next release. No rush to merge this, just raising it whilst I remember to do it.