### PR TITLE
Fix/log get protocol

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix: log about getProtocol result
 - Fix: ensure protocol exists before remove it (#234)
 - Fix: print URI in logs about redirection error (#232)
 - Upgrade NodeJS version from 10 to 12 in Dockerfile due to Node 10 End-of-Life

--- a/lib/services/protocolData.js
+++ b/lib/services/protocolData.js
@@ -93,7 +93,7 @@ function getProtocol(protocol, callback) {
         } else if (error) {
             callback(error);
         } else {
-            var resource = 'n/a';
+            const resource = 'n/a';
             callback(new errors.ProtocolNotFound(resource, protocol));
         }
     });

--- a/lib/services/protocolData.js
+++ b/lib/services/protocolData.js
@@ -87,13 +87,14 @@ function getProtocol(protocol, callback) {
     };
     const query = Protocol.model.find(condition).sort();
 
-    query.exec(function (error, protocol) {
-        if (!error && protocol && protocol.length === 1) {
-            callback(null, protocol[0]);
+    query.exec(function (error, protocolFound) {
+        if (!error && protocolFound && protocolFound.length === 1) {
+            callback(null, protocolFound[0]);
         } else if (error) {
             callback(error);
         } else {
-            callback(new errors.ProtocolNotFound(protocol));
+            var resource = 'n/a';
+            callback(new errors.ProtocolNotFound(resource, protocol));
         }
     });
 }


### PR DESCRIPTION
to avoid this kind of wrong log:

```
time=2021-03-05T07:49:08.645Z | lvl=DEBUG | corr=177eb438-4325-49a1-a549-5baa8109a767 | trans=177eb438-4325-49a1-a549-5baa8109a767 | op=IoTAManager.ProtocolAPI | from=n/a | srv=n/a | subsrv=n/a | msg=Removing protocol with id [IoTA-JSON] | comp=IoTAgentManager
time=2021-03-05T07:49:08.649Z | lvl=ERROR | corr=c7c0ee6a-ec62-434b-bdb1-26d665add68c | trans=c7c0ee6a-ec62-434b-bdb1-26d665add68c | op=IoTAgentNGSI.Alarms | from=n/a | srv=n/a | subsrv=n/a | msg=Raising [MONGO-ALARM]: {"name":"PROTOCOL_NOT_FOUND","message":"Protocol not found for resource [] and protocol [undefined]","code":404} | comp=IoTAgentManager
```
