### PR TITLE
Add graceful shutdown

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- FIX: Add graceful shutdown listening to SIGINT (#263)

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ The following sections show the available options in detail.
 
 ### Start
 
-Runs a local version of the IoT Agent
+Runs a local version of the IoT Manager
 
 ```bash
 npm start

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The Docker automatically starts listening in the API ports, so there is no need 
 the application running. The Docker image will automatically start.
 
 In order to run the docker image, first you must have a MongoDB instance running. You can achieve this by executing the
-followin command:
+following command:
 
 ```console
 docker run --name mongodb -d mongo

--- a/README.md
+++ b/README.md
@@ -4,118 +4,138 @@
 
 ## Index
 
-* [Overview](#overview)
-* [Configuration](#configuration)
-* [Installation](#installation)
-* [Usage](#usage)
-* [Subscription API](#subscriptionapi)
-* [Development Documentation](#development)
+-   [Overview](#overview)
+-   [Configuration](#configuration)
+-   [Installation](#installation)
+-   [Usage](#usage)
+-   [Subscription API](#subscriptionapi)
+-   [Development Documentation](#development)
 
 ## <a name="overview"/> Overview
+
 ### Description
-The IoT Agent Manager works as a proxy for scenarios where multiple IoT Agents offer different southbound protocols.
-The IoTA Manager appears as a single administration endpoint for provisioning tasks, redirecting provisioning requests
-to the appropriate IoTAgent based on the declared protocol.
+
+The IoT Agent Manager works as a proxy for scenarios where multiple IoT Agents offer different southbound protocols. The
+IoTA Manager appears as a single administration endpoint for provisioning tasks, redirecting provisioning requests to
+the appropriate IoTAgent based on the declared protocol.
 
 The IoTAgent Manager also offers a cache of all the provided device Configurations, to fasten the retrieval of certain
 information from the Agents.
 
-Additional information about operating the component can be found in the [Operations: logs and alarms](docs/operations.md) document.
+Additional information about operating the component can be found in the [Operations: logs and
+alarms](docs/operations.md) document.
 
 ## <a name="configuration"/> Configuration
+
 The IoT Agent Manager main configuration point is the `config.js` file at the root of the project. The following section
 explains each configuration parameter in detail.
 
 ### Configuration parameters
-* **server.port**: port where the server will be listening for connections.
-* **server.host**: address the server will bind to.
-* **mongodb.host**: host where the Mongo DB instance is listening.
-* **mongodb.port**: port where the Mongo DB instance is listening.
-* **mongodb.db**: name of the Mongo DB database to use.
-* **logLevel**: set the log level for the internal logger. Its allowed values are: FATAL, ERROR, WARNING, INFO and DEBUG.
+
+-   **server.port**: port where the server will be listening for connections.
+-   **server.host**: address the server will bind to.
+-   **mongodb.host**: host where the Mongo DB instance is listening.
+-   **mongodb.port**: port where the Mongo DB instance is listening.
+-   **mongodb.db**: name of the Mongo DB database to use.
+-   **logLevel**: set the log level for the internal logger. Its allowed values are: FATAL, ERROR, WARNING, INFO and
+    DEBUG.
 
 ### Environment variables
+
 Some of the configuration parameters can also be modified using environment variables when starting the process. The
 following table shows the correspondence between allowed environment variables and configuration parameters.
 
-| Environment variable      | Configuration attribute             |
-|:------------------------- |:----------------------------------- |
-| IOTA_SERVER_PORT          | server.port                         |
-| IOTA_SERVER_HOST          | server.host                         |
-| IOTA_MONGO_HOST           | mongodb.host                        |
-| IOTA_MONGO_PORT           | mongodb.port                        |
-| IOTA_MONGO_REPLICASET     | mongodb.replicaSet                  |
-| IOTA_MONGO_DB             | mongodb.db                          |
-| IOTA_LOG_LEVEL            | logLevel                            |
+| Environment variable  | Configuration attribute |
+| :-------------------- | :---------------------- |
+| IOTA_SERVER_PORT      | server.port             |
+| IOTA_SERVER_HOST      | server.host             |
+| IOTA_MONGO_HOST       | mongodb.host            |
+| IOTA_MONGO_PORT       | mongodb.port            |
+| IOTA_MONGO_REPLICASET | mongodb.replicaSet      |
+| IOTA_MONGO_DB         | mongodb.db              |
+| IOTA_LOG_LEVEL        | logLevel                |
 
 ## <a name="installation"/> Installation
+
 There are two ways of installing the IoT Agent Manager: using Git or RPMs.
 
 ### Using GIT
+
 In order to install the IoT Agent Manager, just clone the project and install the dependencies:
-```
+
+```console
 git clone https://github.com/telefonicaid/iotagent-manager.git
 npm install
 ```
+
 In order to start the IoT Agent Manager, from the root folder of the project, type:
-```
+
+```console
 bin/iota-manager
 ```
 
 ### Using RPM
+
 The project contains a script for generating an RPM that can be installed in Red Hat 6.5 compatible Linux distributions.
 The RPM depends on Node.js 0.10 version, so EPEL repositories are advisable.
 
 In order to create the RPM, execute the following scritp, inside the `/rpm` folder:
-```
+
+```console
 create-rpm.sh -v <versionNumber> -r <releaseNumber>
 ```
 
 Once the RPM is generated, it can be installed using the followogin command:
-```
+
+```console
 yum localinstall --nogpg <nameOfTheRPM>.rpm
 ```
 
 The IoTA Manager will then be installed as a linux service, and can ve started with the `service` command as usual:
-```
+
+```console
 service iotamanager start
 ```
 
 ### Docker installation
-The Docker automatically starts listening in the API ports, so there is no need to execute any process in order to
-have the application running. The Docker image will automatically start.
 
-In order to run the docker image, first you must have a MongoDB instance running. You can achieve this by executing
-the followin command:
-```
+The Docker automatically starts listening in the API ports, so there is no need to execute any process in order to have
+the application running. The Docker image will automatically start.
+
+In order to run the docker image, first you must have a MongoDB instance running. You can achieve this by executing the
+followin command:
+
+```console
 docker run --name mongodb -d mongo
 ```
 
 ### Build your own Docker image
+
 There is also the possibility to build your own local Docker image of the IOTagent-manager component.
 
 To do it, follow the next steps once you have installed Docker in your machine:
 
 1. Navigate to the path where the component repository was cloned.
 2. Launch a Docker build
-    * Using the default NodeJS version of the operating system used defined in FROM keyword of Dockerfile:
+    - Using the default NodeJS version of the operating system used defined in FROM keyword of Dockerfile:
     ```bash
     sudo docker build -f Dockerfile .
     ```
-    * Using an alternative NodeJS version:
+    - Using an alternative NodeJS version:
     ```bash
     sudo docker build --build-arg NODEJS_VERSION=0.10.46 -f Dockerfile .
     ```
 
 Once the MongoDB instance is running, you can execute the IoT Manager with the following command:
-```
+
+```console
 docker run -d  --link mongodb:mongo -e "IOTA_LOG_LEVEL=DEBUG" -e "IOTA_MONGO_HOST=mongo" -p 8082:8082 telefonicaiot/iotamanager
 ```
 
 ### Using PM2
 
-The IoT Agent Manager within the Docker image can be run encapsulated within the [pm2](http://pm2.keymetrics.io/) Process
-Manager by adding the `PM2_ENABLED` environment variable.
+The IoT Agent Manager within the Docker image can be run encapsulated within the [pm2](http://pm2.keymetrics.io/)
+Process Manager by adding the `PM2_ENABLED` environment variable.
 
 ```console
 docker run --name iotagent-manager -e PM2_ENABLED=true -d fiware/iotagent-manager
@@ -125,54 +145,59 @@ Use of pm2 is **disabled** by default. It is unnecessary and counterproductive t
 your dockerized environment is already configured to restart Node.js processes whenever they exit (e.g. when using
 [Kubernetes](https://kubernetes.io/))
 
-
 ## <a name="usage"/> Usage
+
 In order to execute the IoT Agent Manager just execute the following command from the root folder:
-```
+
+```console
 bin/iota-manager.js
 ```
+
 This will start the IoT Agent Manager in the foreground. Use standard linux commands to start it in background.
 
 When started with no arguments, the IoT Agent Manager will expect to find a `config.js` file with the configuration in
-the root folder. An argument can be passed with the path to a new configuration file (relative to the application folder)
-to be used instead of the default one.
+the root folder. An argument can be passed with the path to a new configuration file (relative to the application
+folder) to be used instead of the default one.
 
 ## <a name="subscriptionapi"/> Subscription API
 
 #### New Subscription (POST /iot/protocols)
-Whenever a new IoT Agent wants to register itself into the IoTAgent Manager, it must send a subscription request to
-the following path: ``, indicating the following information:
-* *protocol*: Name of the protocol served by the IoTAgent.
-* *description*: Textual description for its display in portals.
-* *iotagent*: URL address where requests for this IoT Agent will be redirected.
-* *resource*: Unique string used to identify different IoT Agents for the same protocol.
-* *services*: List of device Configurations available in the IoT Agent. The IoTA Manager saves a cache for all the
-configurations, aimed to be used to fasten the operations agains the IoTA databases.
+
+Whenever a new IoT Agent wants to register itself into the IoTAgent Manager, it must send a subscription request to the
+following path: ``, indicating the following information:
+
+-   _protocol_: Name of the protocol served by the IoTAgent.
+-   _description_: Textual description for its display in portals.
+-   _iotagent_: URL address where requests for this IoT Agent will be redirected.
+-   _resource_: Unique string used to identify different IoT Agents for the same protocol.
+-   _services_: List of device Configurations available in the IoT Agent. The IoTA Manager saves a cache for all the
+    configurations, aimed to be used to fasten the operations agains the IoTA databases.
 
 The following example shows a registration of an IoT Agent that already have some configuration groups registered in the
 IoT Agent:
-```
+
+```json
 {
-  "protocol": "GENERIC_PROTOCOL",
-  "description": "A generic protocol",
-  "iotagent": "http://smartGondor.com/iot",
-  "resource": "/iot/d",
-  "services": [
-    {
-      "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
-      "token": "8970A9078A803H3BL98PINEQRW8342HBAMS",
-      "entity_type": "SensorMachine",
-      "resource": "/deviceTest",
-      "service": "theService",
-      "service_path": "theSubService",
-      "attributes": [
+    "protocol": "GENERIC_PROTOCOL",
+    "description": "A generic protocol",
+    "iotagent": "http://smartGondor.com/iot",
+    "resource": "/iot/d",
+    "services": [
         {
-          "name": "status",
-          "type": "Boolean"
+            "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
+            "token": "8970A9078A803H3BL98PINEQRW8342HBAMS",
+            "entity_type": "SensorMachine",
+            "resource": "/deviceTest",
+            "service": "theService",
+            "service_path": "theSubService",
+            "attributes": [
+                {
+                    "name": "status",
+                    "type": "Boolean"
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }
 ```
 
@@ -181,43 +206,52 @@ IoTAgent Manager with the same protocol and resource of an already existing agen
 new information.
 
 #### List subscriptions (GET /iot/protocols)
+
 Retrieve the list of all the available protocols, with their available endpoints. The following example shows a sample
 response from the server:
-```
+
+```json
 {
-   "count": 1,
-   "protocols": [
-     {
-       "protocol" : "PDI-IoTA-UltraLight",
-       "description" : "UL2",
-       "endpoints" : [
-          { "endpoint" : "http://127.0.0.1:8080/iot",
-            "identifier" : "idcl1:8080",
-            "resource" : "/iot/d"
-          }
-        ]
-     }
+    "count": 1,
+    "protocols": [
+        {
+            "protocol": "PDI-IoTA-UltraLight",
+            "description": "UL2",
+            "endpoints": [{ "endpoint": "http://127.0.0.1:8080/iot", "identifier": "idcl1:8080", "resource": "/iot/d" }]
+        }
     ]
- }
+}
 ```
 
 The list accepts to query parameters:
-* *limit*: limits the number of entries to return from the query.
-* *offset*: skips the given number of entries from the database before returning the list.
 
+-   _limit_: limits the number of entries to return from the query.
+-   _offset_: skips the given number of entries from the database before returning the list.
 
 ## <a name="development"/> Development documentation
+
 ### Project build
+
 The project is managed using npm.
 
 For a list of available task, type
+
 ```bash
 npm run
 ```
 
 The following sections show the available options in detail.
 
+### Start
+
+Runs a local version of the IoT Agent
+
+```bash
+npm start
+```
+
 ### Testing
+
 [Mocha](http://visionmedia.github.io/mocha/) Test Runner + [Should.js](https://shouldjs.github.io/) Assertion Library.
 
 The test environment is preconfigured to run BDD testing style.
@@ -233,10 +267,10 @@ npm test
 ```
 
 ### Coding guidelines
+
 jshint
 
-Uses provided .jshintrc flag file.
-To check source code style, type
+Uses provided .jshintrc flag file. To check source code style, type
 
 ```bash
 npm run lint
@@ -244,8 +278,7 @@ npm run lint
 
 ### Continuous testing
 
-Support for continuous testing by modifying a src file or a test.
-For continuous testing, type
+Support for continuous testing by modifying a src file or a test. For continuous testing, type
 
 ```bash
 npm run test:watch
@@ -258,6 +291,7 @@ npm run watch
 ```
 
 ### Code Coverage
+
 Istanbul
 
 Analizes the code coverage of your tests.
@@ -271,7 +305,8 @@ npm run test:coverage
 
 ### Clean
 
-Removes `node_modules` and `coverage` folders, and  `package-lock.json` file so that a fresh copy of the project is restored.
+Removes `node_modules` and `coverage` folders, and `package-lock.json` file so that a fresh copy of the project is
+restored.
 
 ```bash
 # Use git-bash on Windows

--- a/lib/iotagent-manager.js
+++ b/lib/iotagent-manager.js
@@ -112,12 +112,21 @@ function startServer(newConfig, callback) {
     northboundServer.server.listen(northboundServer.app.get('port'), northboundServer.app.get('host'), callback);
 }
 
+/**
+ * Starts the IoT Manager with the given configuration.
+ *
+ * @param {Object} newConfig        New configuration object.
+ */
 function start(newConfig, callback) {
     config.setConfig(newConfig);
 
     async.series([apply(startServer, newConfig), dbConn.configureDb], callback);
 }
 
+/**
+ * Stops the current IoT Manager
+ *
+ */
 function stop(callback) {
     logger.info(context, 'Stopping IoTA Manager');
 
@@ -127,6 +136,25 @@ function stop(callback) {
         callback();
     }
 }
+
+/**
+ * Shuts down the IoT Manager in a graceful manner
+ *
+ */
+function handleShutdown(signal) {
+    logger.fatal(context, 'Received %s, starting shutdown processs', signal);
+    stop((err) => {
+        if (err) {
+            logger.error(context, err);
+            return process.exit(1);
+        }
+        return process.exit(0);
+    });
+}
+
+process.on('SIGINT', handleShutdown);
+process.on('SIGTERM', handleShutdown);
+process.on('SIGHUP', handleShutdown);
 
 exports.start = start;
 exports.stop = stop;

--- a/lib/iotagent-manager.js
+++ b/lib/iotagent-manager.js
@@ -142,7 +142,7 @@ function stop(callback) {
  *
  */
 function handleShutdown(signal) {
-    logger.fatal(context, 'Received %s, starting shutdown processs', signal);
+    logger.info(context, 'Received %s, starting shutdown processs', signal);
     stop((err) => {
         if (err) {
             logger.error(context, err);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clean": "rm -rf package-lock.json && rm -rf node_modules && rm -rf coverage && rm -rf .nyc_output",
     "healthcheck": "node ./bin/healthcheck",
     "lint": "eslint lib/ bin/iota-manager test/ --cache --fix",
+    "start": "node ./bin/iotagent-manager",
     "test": "nyc --reporter=text mocha --recursive 'test/**/*.js' --reporter spec --timeout 3000 --ui bdd --exit --color true",
     "test:coverage": "nyc --reporter=lcov mocha -- --recursive 'test/**/*.js' --reporter spec --exit",
     "test:watch": "npm run test -- -w ./lib",


### PR DESCRIPTION
When a shutdown signal is sent, we need to do graceful shutdown out of Node.js and Express to avoid side effects
like finishing active requests before closing server, clean up resources, db connections etc.

see: https://stackfame.com/node-express-graceful-shutdown