### PR TITLE
Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - FIX: Add graceful shutdown listening to SIGINT (#263)
+- Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "body-parser": "~1.19.0",
     "express": "4.16.4",
     "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
-    "logops": "2.1.0",
+    "logops": "2.1.2",
     "mongoose": "5.11.20",
     "request": "2.88.0",
     "revalidator": "~0.3.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "async": "2.6.2",
     "body-parser": "~1.19.0",
     "express": "4.16.4",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
     "logops": "2.1.2",
     "mongoose": "5.11.20",
     "request": "2.88.0",


### PR DESCRIPTION
logops < 2.1.2 depends on colors dependency, which recently have a corruption problem: https://snyk.io/blog/open-source-npm-packages-colors-faker/
