### PR TITLE
Update iotaRedirector.js

### DIFF
--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -392,7 +392,6 @@ function processRequests(req, res, next) {
             logger.error(context, 'The redirection ended up in error: ', error);
             next(error);
         } else {
-            logger.debug(context, 'results %j', results);
             const statusCodes = _.uniq(results.map(extractStatusCode));
             if (statusCodes.length === 1) {
                 if (req.method === 'POST' || req.method === 'DELETE' || req.method === 'PUT') {


### PR DESCRIPTION
This PR just erases a useful log:

time=2022-02-23T16:15:44.570Z | lvl=DEBUG | corr=84073a5d-f9d1-4090-9596-e5e7a4fa5411 | trans=84073a5d-f9d1-4090-9596-e5e7a4fa5411 | op=IoTAManager.Redirector | from=n/a | srv=fi001012 | subsrv=/ssfi001012 | msg=results [Circular] | comp=IoTAgentManager

No CNR provided