### PR TITLE
Add support to API route `/iot/groups ` (`/iot/services` still supported)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,2 @@
+- Add /iot/groups API endpoints support (as equivalent to /iot/services) (#270)
+- Deprecated: /iot/services API routes

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-- Add /iot/groups API endpoints support (as equivalent to /iot/services) (#270)
+- Add: /iot/groups API endpoints support (as equivalent to /iot/services) (#270)
 - Deprecated: /iot/services API routes

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ following path: ``, indicating the following information:
 -   _description_: Textual description for its display in portals.
 -   _iotagent_: URL address where requests for this IoT Agent will be redirected.
 -   _resource_: Unique string used to identify different IoT Agents for the same protocol.
--   _services_: List of device Configurations available in the IoT Agent. The IoTA Manager saves a cache for all the
+-   groups: List of device Configurations available in the IoT Agent. The IoTA Manager saves a cache for all the
     configurations, aimed to be used to fasten the operations agains the IoTA databases.
 
 The following example shows a registration of an IoT Agent that already have some configuration groups registered in the
@@ -184,7 +184,7 @@ IoT Agent:
     "description": "A generic protocol",
     "iotagent": "http://smartGondor.com/iot",
     "resource": "/iot/d",
-    "services": [
+    "groups": [
         {
             "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
             "token": "8970A9078A803H3BL98PINEQRW8342HBAMS",

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ following path: ``, indicating the following information:
 -   _description_: Textual description for its display in portals.
 -   _iotagent_: URL address where requests for this IoT Agent will be redirected.
 -   _resource_: Unique string used to identify different IoT Agents for the same protocol.
--   groups: List of device Configurations available in the IoT Agent. The IoTA Manager saves a cache for all the
+-   _groups_: List of device Configurations available in the IoT Agent. The IoTA Manager saves a cache for all the
     configurations, aimed to be used to fasten the operations agains the IoTA databases.
 
 The following example shows a registration of an IoT Agent that already have some configuration groups registered in the

--- a/lib/services/configurations.js
+++ b/lib/services/configurations.js
@@ -118,14 +118,25 @@ function handleListRequest(req, res, next) {
             if (error) {
                 next(error);
             } else {
-                res.status(200).json(translateToApi(logger, configurations));
+                res.status(200).json(modifyPayload(req, translateToApi(logger, configurations))); // #FIXME341 - Remove modifyPayload() usage when dropping /iot/services endpoint
             }
         }
     );
 }
+// #FIXME341 - Remove this function when dropping /iot/services endpoint
+function modifyPayload(req, payload) {
+    if (req._parsedUrl.pathname === '/iot/groups') {
+        if (payload.services) {
+            payload.groups = payload.services;
+            delete payload.services;
+        }
+    }
+    return payload;
+}
 
 function loadContextRoutes(router) {
-    router.get('/iot/services', [validateListParameters, handleListRequest]);
+    router.get('/iot/services', [validateListParameters, handleListRequest]); // #FIXME341 - Remove this function when dropping /iot/services endpoint
+    router.get('/iot/groups', [validateListParameters, handleListRequest]);
 }
 
 exports.loadContextRoutes = loadContextRoutes;

--- a/lib/services/iotaRedirector.js
+++ b/lib/services/iotaRedirector.js
@@ -31,7 +31,10 @@ function guessCollection(body) {
     if (body.services) {
         return 'services';
     } else if (body.devices) {
+        // #FIXME341 - Remove this part of the code when dropping /iot/services endpoint
         return 'devices';
+    } else if (body.groups) {
+        return 'groups';
     }
     return null;
 }
@@ -214,15 +217,24 @@ function createRequest(req, protocol, body) {
 
     options.uri = protocolAddress + req.path;
 
+    // #FIXME341 - Remove this part of the code when dropping /iot/services endpoint
     if (body && body.services) {
         body.services = body.services.map(function cleanProtocol(item) {
             delete item.protocol;
             return item;
         });
-        // Translate body.services
-
         if (req.method === 'PUT') {
             body = body.services[0];
+        }
+    }
+
+    if (body && body.groups) {
+        body.groups = body.groups.map(function cleanProtocol(item) {
+            delete item.protocol;
+            return item;
+        });
+        if (req.method === 'PUT') {
+            body = body.groups[0];
         }
     }
 
@@ -333,7 +345,10 @@ function processRequests(req, res, next) {
             if (results[0][1].devices || results[0][1].device_id) {
                 collectionName = 'devices';
             } else if (results[0][1].services) {
+                // #FIXME341 - Remove this part of the code when dropping /iot/services endpoint
                 collectionName = 'services';
+            } else if (results[0][1].groups) {
+                collectionName = 'groups';
             } else {
                 return null;
             }
@@ -413,8 +428,10 @@ function processRequests(req, res, next) {
 
 function loadContextRoutes(router) {
     const middlewareList = [queryParamExtractor, getProtocols, createRequests, processRequests];
-
-    router.post('/iot/services', middlewareList);
+    router.post('/iot/groups', middlewareList);
+    router.put('/iot/groups', middlewareList);
+    router.delete('/iot/groups', middlewareList);
+    router.post('/iot/services', middlewareList); // #FIXME341 - Remove this part of the code when dropping /iot/services endpoint
     router.post('/iot/devices', middlewareList);
     router.put('/iot/services', middlewareList);
     router.delete('/iot/services', middlewareList);

--- a/lib/services/protocols.js
+++ b/lib/services/protocols.js
@@ -88,11 +88,24 @@ function deleteProtocol(req, res, next) {
     });
 }
 
+// #FIXME341 - Remove this function of the code when dropping /iot/services endpoint
+function multipleValidation(req, res, next) {
+    const logger = req.logger;
+    const body = req.body;
+
+    if (body.groups) {
+        logger.debug('Validating protocol with groups');
+        body.services = body.groups;
+        delete body.groups;
+    }
+    middleware.validateJson(protocolTemplate)(req, res, next);
+}
+
 function loadContextRoutes(router) {
     router.get('/iot/protocols', [readProtocolList, handleProtocolList]);
 
     router.post('/iot/protocols', [
-        middleware.validateJson(protocolTemplate),
+        multipleValidation, // #FIXME341 - Remove calling this function when dropping /iot/services endpoint
         saveProtocol,
         returnProtocolCreationResponse
     ]);

--- a/test/examples/protocols/registrationEmpty.json
+++ b/test/examples/protocols/registrationEmpty.json
@@ -3,5 +3,5 @@
   "description": "A generic protocol",
   "iotagent": "http://smartGondor.com/",
   "resource": "/iot/d",
-  "services": []
+  "groups": []
 }

--- a/test/examples/protocols/registrationWithGroups.json
+++ b/test/examples/protocols/registrationWithGroups.json
@@ -3,7 +3,7 @@
   "description": "A generic protocol",
   "iotagent": "http://smartGondor.com/",
   "resource": "/iot/d",
-  "services": [
+  "groups": [
     {
       "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
       "token": "8970A9078A803H3BL98PINEQRW8342HBAMS",

--- a/test/examples/protocols/registrationWithGroupsUpdate.json
+++ b/test/examples/protocols/registrationWithGroupsUpdate.json
@@ -3,7 +3,7 @@
   "description": "A generic protocol updated with new information",
   "iotagent": "http://smartGondor.com/New",
   "resource": "/iot/d",
-  "services": [
+  "groups": [
     {
       "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
       "token": "8970A9078A803H3BL98PINEQRW8342HBAMS",

--- a/test/examples/protocols/registrationWithMissingAttrs.json
+++ b/test/examples/protocols/registrationWithMissingAttrs.json
@@ -2,7 +2,7 @@
   "description": "A generic protocol",
   "iotagent": "http://smartGondor.com/",
   "resource": "/iot/d",
-  "services": [
+  "groups": [
     {
       "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
       "token": "8970A9078A803H3BL98PINEQRW8342HBAMS",

--- a/test/examples/protocols/registrationWithNewGroups.json
+++ b/test/examples/protocols/registrationWithNewGroups.json
@@ -3,7 +3,7 @@
   "description": "A generic protocol",
   "iotagent": "http://smartGondor.com/",
   "resource": "/iot/d",
-  "services": [
+  "groups": [
     {
       "apikey": "L23123HJ01230BJ4HV87K0BMSA807898PI9H2",
       "token": "90DSFLK3Y9032NEQL8970A92HBARW83403H3",

--- a/test/examples/protocols/registrationWithWrongAttrs.json
+++ b/test/examples/protocols/registrationWithWrongAttrs.json
@@ -4,7 +4,7 @@
   "iotagent": "http://smartGondor.com/",
   "APIKey": "567586gyh rtygooytrdytfcy7567",
   "service": "SmartGondor",
-  "services": [
+  "groups": [
     {
       "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
       "token": "8970A9078A803H3BL98PINEQRW8342HBAMS",

--- a/test/examples/provisioning/getGroupList.json
+++ b/test/examples/provisioning/getGroupList.json
@@ -1,5 +1,5 @@
 {
-  "services": [
+  "groups": [
     {
       "resource": "/deviceTest",
       "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",

--- a/test/examples/provisioning/postCleanGroup1.json
+++ b/test/examples/provisioning/postCleanGroup1.json
@@ -1,5 +1,5 @@
 {
-  "services": [
+  "groups": [
     {
       "resource": "/iot/d",
       "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",

--- a/test/examples/provisioning/postCleanGroup2.json
+++ b/test/examples/provisioning/postCleanGroup2.json
@@ -1,5 +1,5 @@
 {
-  "services": [
+  "groups": [
     {
       "resource": "/iot/a",
       "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",

--- a/test/examples/provisioning/postGroup.json
+++ b/test/examples/provisioning/postGroup.json
@@ -1,5 +1,5 @@
 {
-  "services": [
+  "groups": [
     {
       "resource": "/deviceTest",
       "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",

--- a/test/examples/provisioning/postGroupArray.json
+++ b/test/examples/provisioning/postGroupArray.json
@@ -1,5 +1,5 @@
 {
-  "services": [
+  "groups": [
     {
       "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
       "entity_type": "SensorMachine",

--- a/test/examples/provisioning/postGroupServices.json
+++ b/test/examples/provisioning/postGroupServices.json
@@ -1,0 +1,36 @@
+{
+  "services": [
+    {
+      "resource": "/deviceTest",
+      "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
+      "entity_type": "SensorMachine",
+      "trust": "8970A9078A803H3BL98PINEQRW8342HBAMS",
+      "cbHost": "http://unexistentHost:1026",
+      "commands": [
+        {
+          "name": "wheel1",
+          "type": "Wheel"
+        }
+      ],
+      "lazy": [
+        {
+          "name": "luminescence",
+          "type": "Lumens"
+        }
+      ],
+      "attributes": [
+        {
+          "name": "status",
+          "type": "Boolean"
+        }
+      ],
+      "static_attributes": [
+        {
+          "name": "bootstrapServer",
+          "type": "Address",
+          "value": "127.0.0.1"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/configuration-retrieval-test.js
+++ b/test/unit/configuration-retrieval-test.js
@@ -73,7 +73,7 @@ describe('Configuration list', function () {
 
                 protocolRequest.headers['fiware-service'] = services[service];
                 protocolRequest.headers['fiware-servicepath'] = newConfiguration.service_path;
-                protocolRequest.json.services.push(newConfiguration);
+                protocolRequest.json.groups.push(newConfiguration);
             }
         }
 
@@ -105,7 +105,7 @@ describe('Configuration list', function () {
 
     describe('When a new configuration list request arrives to the IoTAM', function () {
         const options = {
-            url: 'http://localhost:' + iotConfig.server.port + '/iot/services',
+            url: 'http://localhost:' + iotConfig.server.port + '/iot/groups',
             headers: {
                 'fiware-service': 'smartGondor',
                 'fiware-servicepath': '/gardens'
@@ -124,20 +124,20 @@ describe('Configuration list', function () {
         it('should return all the available configurations for its service', function (done) {
             request(options, function (error, response, body) {
                 // It should be greather than 7 but due to some mongodb-travis isses was fixed to 2
-                body.services.length.should.greaterThan(2);
+                body.groups.length.should.greaterThan(2);
                 done();
             });
         });
 
         it('should map the attributes for the configurations appropriately', function (done) {
             request(options, function (error, response, body) {
-                for (let i = 0; i < body.services.length; i++) {
-                    should.exist(body.services[i].entity_type);
-                    should.not.exist(body.services[i].type);
-                    should.exist(body.services[i].service_path);
-                    should.not.exist(body.services[i].subservice);
-                    should.exist(body.services[i].internal_attributes);
-                    should.not.exist(body.services[i].internalAttributes);
+                for (let i = 0; i < body.groups.length; i++) {
+                    should.exist(body.groups[i].entity_type);
+                    should.not.exist(body.groups[i].type);
+                    should.exist(body.groups[i].service_path);
+                    should.not.exist(body.groups[i].subservice);
+                    should.exist(body.groups[i].internal_attributes);
+                    should.not.exist(body.groups[i].internalAttributes);
                 }
 
                 done();
@@ -148,8 +148,8 @@ describe('Configuration list', function () {
             request(options, function (error, response, body) {
                 let otherServiceFound = false;
 
-                for (let i = 0; i < body.services.length; i++) {
-                    if (body.services[i].service !== 'smartGondor') {
+                for (let i = 0; i < body.groups.length; i++) {
+                    if (body.groups[i].service !== 'smartGondor') {
                         otherServiceFound = true;
                     }
                 }
@@ -162,7 +162,7 @@ describe('Configuration list', function () {
 
     describe('When a configuration list request with a limit 3 arrives to the IoTAM', function () {
         const options = {
-            url: 'http://localhost:' + iotConfig.server.port + '/iot/services',
+            url: 'http://localhost:' + iotConfig.server.port + '/iot/groups',
             headers: {
                 'fiware-service': 'smartGondor',
                 'fiware-servicepath': '/gardens'
@@ -175,7 +175,7 @@ describe('Configuration list', function () {
 
         it('should return just 3 results', function (done) {
             request(options, function (error, response, body) {
-                body.services.length.should.equal(3);
+                body.groups.length.should.equal(3);
                 done();
             });
         });
@@ -183,7 +183,7 @@ describe('Configuration list', function () {
 
     describe('When a configuration list request with a offset 3 arrives to the IoTAM', function () {
         const options = {
-            url: 'http://localhost:' + iotConfig.server.port + '/iot/services',
+            url: 'http://localhost:' + iotConfig.server.port + '/iot/groups',
             headers: {
                 'fiware-service': 'smartGondor',
                 'fiware-servicepath': '/gardens'
@@ -197,7 +197,7 @@ describe('Configuration list', function () {
         it('should skip the first 3 results', function (done) {
             request(options, function (error, response, body) {
                 // It should be greather than 3 but due to some mongodb-travis isses was fixed to 0
-                body.services.length.should.greaterThan(-1);
+                body.groups.length.should.greaterThan(-1);
                 done();
             });
         });
@@ -205,7 +205,7 @@ describe('Configuration list', function () {
 
     describe('When a configuration list request arrives with a wrong limit', function () {
         const options = {
-            url: 'http://localhost:' + iotConfig.server.port + '/iot/services',
+            url: 'http://localhost:' + iotConfig.server.port + '/iot/groups',
             headers: {
                 'fiware-service': 'smartGondor',
                 'fiware-servicepath': '/gardens'
@@ -226,7 +226,7 @@ describe('Configuration list', function () {
 
     describe('When a configuration list request arrives with a wrong offset', function () {
         const options = {
-            url: 'http://localhost:' + iotConfig.server.port + '/iot/services',
+            url: 'http://localhost:' + iotConfig.server.port + '/iot/groups',
             headers: {
                 'fiware-service': 'smartGondor',
                 'fiware-servicepath': '/gardens'

--- a/test/unit/iotaRedirections-test.js
+++ b/test/unit/iotaRedirections-test.js
@@ -55,9 +55,18 @@ describe('IoTA Redirections', function () {
 
         ['DELETE Device', null, 'DELETE', '/iot/devices/devId'],
         ['POST Device', './test/examples/provisioning/postDevice.json', 'POST', '/iot/devices'],
-        ['POST Configuration', './test/examples/provisioning/postGroup.json', 'POST', '/iot/groups'],
-        ['PUT Configuration', './test/examples/provisioning/putGroup.json', 'PUT', '/iot/groups'],
-        ['DELETE Configuration', null, 'DELETE', '/iot/groups']
+        ['POST Configuration (/iot/groups)', './test/examples/provisioning/postGroup.json', 'POST', '/iot/groups'],
+        ['PUT Configuration (/iot/groups)', './test/examples/provisioning/putGroup.json', 'PUT', '/iot/groups'],
+        ['DELETE Configuration (/iot/groups)', null, 'DELETE', '/iot/groups'],
+        // #FIXME341 - Remove those test cases when dropping /iot/services endpoint
+        [
+            'POST Configuration (/iot/services)',
+            './test/examples/provisioning/postGroupServices.json',
+            'POST',
+            '/iot/services'
+        ],
+        ['PUT Configuration (/iot/services)', './test/examples/provisioning/putGroup.json', 'PUT', '/iot/services'],
+        ['DELETE Configuration (/iot/services)', null, 'DELETE', '/iot/services']
     ];
     const protocolRequest = {
         url: 'http://localhost:' + iotConfig.server.port + '/iot/protocols',

--- a/test/unit/iotaRedirections-test.js
+++ b/test/unit/iotaRedirections-test.js
@@ -55,9 +55,9 @@ describe('IoTA Redirections', function () {
 
         ['DELETE Device', null, 'DELETE', '/iot/devices/devId'],
         ['POST Device', './test/examples/provisioning/postDevice.json', 'POST', '/iot/devices'],
-        ['POST Configuration', './test/examples/provisioning/postGroup.json', 'POST', '/iot/services'],
-        ['PUT Configuration', './test/examples/provisioning/putGroup.json', 'PUT', '/iot/services'],
-        ['DELETE Configuration', null, 'DELETE', '/iot/services']
+        ['POST Configuration', './test/examples/provisioning/postGroup.json', 'POST', '/iot/groups'],
+        ['PUT Configuration', './test/examples/provisioning/putGroup.json', 'PUT', '/iot/groups'],
+        ['DELETE Configuration', null, 'DELETE', '/iot/groups']
     ];
     const protocolRequest = {
         url: 'http://localhost:' + iotConfig.server.port + '/iot/protocols',
@@ -193,7 +193,7 @@ describe('IoTA Redirections', function () {
 
     describe('When a request arrives to the manager with an array of protocols', function () {
         const options = {
-            url: 'http://localhost:' + iotConfig.server.port + '/iot/services',
+            url: 'http://localhost:' + iotConfig.server.port + '/iot/groups',
             method: 'POST',
             headers: {
                 'fiware-service': 'smartGondor',
@@ -209,7 +209,7 @@ describe('IoTA Redirections', function () {
                 .matchHeader('fiware-servicepath', '/gardens');
 
             agentMock
-                .post('/iot/services', utils.readExampleFile('./test/examples/provisioning/postCleanGroup1.json'))
+                .post('/iot/groups', utils.readExampleFile('./test/examples/provisioning/postCleanGroup1.json'))
                 .query({ resource: '/iot/d', protocol: 'GENERIC_PROTOCOL' })
                 .reply(200, {});
 
@@ -218,7 +218,7 @@ describe('IoTA Redirections', function () {
                 .matchHeader('fiware-servicepath', '/gardens');
 
             secondAgentMock
-                .post('/iot/services', utils.readExampleFile('./test/examples/provisioning/postCleanGroup2.json'))
+                .post('/iot/groups', utils.readExampleFile('./test/examples/provisioning/postCleanGroup2.json'))
                 .query({ resource: '/iot/a', protocol: 'ANOTHER_PROTOCOL' })
                 .reply(200, {});
 


### PR DESCRIPTION
This PR fix #270 
This PR overpass #340 

- [x] Tests 
- [x] Code 
- [x] Doc