### PR TITLE
FIX ci.yml to add new node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
         node-version:
           - 16.x
           - 18.x
+          - 20.x
+          - 22.x
+          - 24.x
     steps:
       - name: Git checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Different from PR https://github.com/telefonicaid/iotagent-json/pull/884 or PR https://github.com/telefonicaid/iotagent-node-lib/pull/1727 in this case step description has not been changed, as in IOTA Manager functional tests are not run.